### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/listing/admin.py
+++ b/listing/admin.py
@@ -17,7 +17,7 @@ class ComicAdmin(admin.ModelAdmin):
     def scrape_issues(self, request, queryset):
         for item in queryset:
             async(scrape_issues, item.pk, item, hook=import_issues)
-        self.message_user(request, '%d comics queued for scraping' % len(queryset))
+        self.message_user(request, '{0:d} comics queued for scraping'.format(len(queryset)))
     scrape_issues.short_description = 'Scrape selected comics'
 
 
@@ -26,7 +26,7 @@ class IssueAdmin(admin.ModelAdmin):
 
     def link_to_comic(self, obj):
         link=urlresolvers.reverse("admin:listing_comic_change", args=[obj.comic.id])
-        return u'<a href="%s">%s</a>' % (link,obj.comic.title)
+        return u'<a href="{0!s}">{1!s}</a>'.format(link, obj.comic.title)
     link_to_comic.allow_tags=True
 
 

--- a/listing/views.py
+++ b/listing/views.py
@@ -67,7 +67,7 @@ class CreatorView(generic.DetailView):
 def refresh_comics(request):
     id = async(scrape_titles, hook=import_titles)
     id = humanize(id)
-    messages.info(request, 'Refreshing comics. Please refresh in a few seconds. id: %s' % id)
+    messages.info(request, 'Refreshing comics. Please refresh in a few seconds. id: {0!s}'.format(id))
     return HttpResponseRedirect(reverse('listing:listing'))
 
 
@@ -75,14 +75,14 @@ def refresh_issues(request, pk):
     comic = Comic.objects.get(pk=pk)
     id = async(scrape_issues, pk, comic, hook=import_issues)
     id = humanize(id)
-    messages.info(request, 'Refreshing issues for %s Please refresh in a few seconds. id: %s' % (comic.title, id))
+    messages.info(request, 'Refreshing issues for {0!s} Please refresh in a few seconds. id: {1!s}'.format(comic.title, id))
     return HttpResponseRedirect(reverse('listing:comic', args=(pk,)))
 
 
 def refresh_creators(request):
     id = async(scrape_creators, hook=import_creators)
     id = humanize(id)
-    messages.info(request, 'Refreshing creators. Please refresh in a few seconds. id: %s' % id)
+    messages.info(request, 'Refreshing creators. Please refresh in a few seconds. id: {0!s}'.format(id))
     return HttpResponseRedirect(reverse('listing:creators'))
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:ZucchiniZe:nightcrawler?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:ZucchiniZe:nightcrawler?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
